### PR TITLE
Fix build on GCC 13

### DIFF
--- a/speed.h
+++ b/speed.h
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <iostream>
+#include <cstdint>
 
 enum class ITESpeed
 {


### PR DESCRIPTION
GCC 13 stopped transitively including `cstdint` in a couple of scenarios [^1], which leads to build failures akin to:

```
[1/25] Compiling C++ object ite-mono.p/speed.cpp.o
FAILED: ite-mono.p/speed.cpp.o
g++ -Iite-mono.p -I. -I.. -I/nix/store/82cq00gwm8zchqaj97kf03h8kc359q54-libusb-1.0.26-dev/include/libusb-1.0 -I/nix/store/x1c6mnx5n7hl85b0r141zp69sw1sd2fg-boost-1.81.0-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c++17 -DBOOST_ALL_NO_LIB -MD -MQ ite-mono.p/speed.cpp.o -MF ite-mono.p/speed.cpp.o.d -o ite-mono.p/speed.cpp.o -c ../speed.cpp
In file included from ../speed.cpp:4:
../speed.h:24:5: error: 'uint8_t' does not name a type
   24 |     uint8_t getDeviceSpeed() const;
      |     ^~~~~~~
../speed.h:6:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    5 | #include <iostream>
  +++ |+#include <cstdint>
    6 |
../speed.cpp:14:43: error: 'uint8_t' was not declared in this scope
   14 | const static std::unordered_map<ITESpeed, uint8_t> speedMap = {
      |                                           ^~~~~~~
../speed.cpp:5:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    4 | #include "speed.h"
  +++ |+#include <cstdint>
    5 |
../speed.cpp:14:50: error: template argument 2 is invalid
   14 | const static std::unordered_map<ITESpeed, uint8_t> speedMap = {
      |                                                  ^
../speed.cpp:14:50: error: template argument 5 is invalid
../speed.cpp:14:52: error: scalar object 'speedMap' requires one element in initializer
   14 | const static std::unordered_map<ITESpeed, uint8_t> speedMap = {
      |                                                    ^~~~~~~~
../speed.cpp:32:1: error: 'uint8_t' does not name a type
   32 | uint8_t Speed::getDeviceSpeed() const
      | ^~~~~~~
../speed.cpp:32:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```

[^1]: https://www.gnu.org/software/gcc/gcc-13/porting_to.html#header-dep-changes